### PR TITLE
feat: 提交时自动剥离图片 GPS 元数据

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Strips GPS / location metadata from image and video files staged for commit.
+# Intentional minimum: drop user-locatable EXIF/QuickTime tags but keep ICC
+# color profile (needed for accurate display).
+#
+# Skip with: git commit --no-verify
+set -euo pipefail
+
+PATTERN='\.(heic|jpe?g|png|webp|avif|mov|mp4|m4v)$'
+
+# Collect staged files (added or modified) matching the pattern.
+files=$(git diff --cached --name-only --diff-filter=AM 2>/dev/null | grep -iE "$PATTERN" || true)
+[ -z "$files" ] && exit 0
+
+if ! command -v exiftool >/dev/null 2>&1; then
+  echo "[pre-commit] exiftool not found in PATH." >&2
+  echo "[pre-commit] Install with: brew install exiftool   (or: apt-get install libimage-exiftool-perl)" >&2
+  echo "[pre-commit] To bypass this hook: git commit --no-verify" >&2
+  exit 1
+fi
+
+modified=()
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  before=$(shasum -a 256 "$f" | cut -d' ' -f1)
+  # -overwrite_original: edit in place, no .orig sidecar
+  # -P: preserve file modification timestamp (avoids mtime churn)
+  # -q -q: suppress info + minor warnings (e.g. PNG without EXIF)
+  # Tag groups stripped:
+  #   gps:all            — EXIF GPS group (HEIC / JPEG iPhone Camera)
+  #   xmp:Geotag         — XMP geotag
+  #   Keys:GPSCoordinates / Keys:LocationInformation — Apple QuickTime (MOV/MP4 Live Photos)
+  exiftool -overwrite_original -P -q -q \
+    -gps:all= \
+    -xmp:Geotag= \
+    -Keys:GPSCoordinates= \
+    -Keys:LocationInformation= \
+    "$f" || true
+  after=$(shasum -a 256 "$f" | cut -d' ' -f1)
+  if [ "$before" != "$after" ]; then
+    modified+=("$f")
+    git add "$f"
+  fi
+done <<< "$files"
+
+if [ ${#modified[@]} -gt 0 ]; then
+  echo "[pre-commit] Stripped GPS/location metadata from:"
+  printf '  %s\n' "${modified[@]}"
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "npm run build && node --test --test-concurrency=1 tests/performance-output.test.mjs tests/media-output.test.mjs"
+    "test": "npm run build && node --test --test-concurrency=1 tests/performance-output.test.mjs tests/media-output.test.mjs",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.0",

--- a/tests/git-hook-pre-commit.test.mjs
+++ b/tests/git-hook-pre-commit.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK_PATH = fileURLToPath(new URL('../.githooks/pre-commit', import.meta.url));
+const SHARP_FIXTURE = fileURLToPath(new URL('./fixtures/sample.png', import.meta.url));
+
+function gpsTagsOf(file) {
+  const out = execFileSync('exiftool', ['-S', '-GPSLatitude', '-GPSLongitude', '-GPSPosition', file]).toString();
+  return out.trim();
+}
+
+async function makeJpegWithGps(path) {
+  const sharp = (await import('sharp')).default;
+  // Make a tiny JPEG from the existing tracked PNG fixture
+  await sharp(SHARP_FIXTURE).jpeg({ quality: 80 }).toFile(path);
+  // Inject GPS coords (San Francisco)
+  execFileSync('exiftool', [
+    '-overwrite_original', '-q',
+    '-GPSLatitude=37.7749', '-GPSLatitudeRef=N',
+    '-GPSLongitude=-122.4194', '-GPSLongitudeRef=W',
+    path,
+  ]);
+}
+
+test('pre-commit hook strips GPS from staged JPEG, keeping the file content otherwise intact', async () => {
+  const repoDir = join(tmpdir(), `gps-hook-${Date.now()}`);
+  await mkdir(repoDir, { recursive: true });
+  try {
+    // Init a fresh repo + identity so commit-related plumbing works
+    const git = (...args) => execFileSync('git', args, { cwd: repoDir, stdio: 'pipe' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    git('config', 'commit.gpgsign', 'false');
+
+    const photo = join(repoDir, 'photo.jpg');
+    await makeJpegWithGps(photo);
+
+    // Sanity: GPS is present pre-stage
+    assert.match(gpsTagsOf(photo), /GPSLatitude/, 'fixture must have GPS before staging');
+
+    git('add', 'photo.jpg');
+
+    // Run the hook with the temp repo as cwd (the hook reads `git diff --cached`)
+    const result = spawnSync('bash', [HOOK_PATH], { cwd: repoDir, encoding: 'utf8' });
+    assert.equal(result.status, 0, `hook exit code: ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stdout, /Stripped GPS\/location metadata/);
+
+    // After hook: GPS should be gone from the file on disk
+    assert.equal(gpsTagsOf(photo).trim(), '', 'GPS tags must be removed');
+
+    // And the file should be re-staged with the cleaned content
+    const stagedShaBefore = git('rev-parse', ':photo.jpg').toString().trim();
+    const fileShaCurrent = git('hash-object', 'photo.jpg').toString().trim();
+    assert.equal(stagedShaBefore, fileShaCurrent, 'cleaned file must be re-staged');
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('pre-commit hook is a no-op when no media files are staged', async () => {
+  const repoDir = join(tmpdir(), `gps-hook-noop-${Date.now()}`);
+  await mkdir(repoDir, { recursive: true });
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repoDir, stdio: 'pipe' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+
+    await writeFile(join(repoDir, 'README.md'), '# hello\n');
+    git('add', 'README.md');
+
+    const result = spawnSync('bash', [HOOK_PATH], { cwd: repoDir, encoding: 'utf8' });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), '', 'no-op should produce no output');
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('pre-commit hook leaves files without GPS untouched (no spurious re-stage)', async () => {
+  const repoDir = join(tmpdir(), `gps-hook-clean-${Date.now()}`);
+  await mkdir(repoDir, { recursive: true });
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repoDir, stdio: 'pipe' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+
+    const sharp = (await import('sharp')).default;
+    const photo = join(repoDir, 'clean.jpg');
+    await sharp(SHARP_FIXTURE).jpeg({ quality: 80 }).toFile(photo);
+    git('add', 'clean.jpg');
+
+    const result = spawnSync('bash', [HOOK_PATH], { cwd: repoDir, encoding: 'utf8' });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), '', 'no Stripped report when nothing was stripped');
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 背景

iPhone 拍的 HEIC、JPEG、Live Photo MOV 默认带 GPS 坐标。把这些文件直接提交进博客 repo 然后 push 到 GitHub Pages，等于在公开站点上暴露家庭位置/常去地点/旅行轨迹。HEIC pipeline (#73) 输出的 AVIF/WebP/JPEG 派生文件已经默认剥 EXIF（sharp 默认行为），但**源文件**仍然以原始 EXIF 形式出现在 git history 里——push 后任何人 clone 都能拿到。

这个 PR 加一个 git pre-commit hook，在 commit 之前原地剥掉 staged 媒体文件的 GPS / 位置标签，源头堵住。

## 改动

**新增** `.githooks/pre-commit` —— 33 行 bash：
- 扫描 `git diff --cached --name-only --diff-filter=AM` 中 `.heic|.jpe?g|.png|.webp|.avif|.mov|.mp4|.m4v` 后缀
- exiftool 原地剥离：`gps:all`、`xmp:Geotag`、`Keys:GPSCoordinates`、`Keys:LocationInformation`
- 保留 ICC 色彩配置文件（不是隐私数据）
- 改动后 `git add` 重新 stage
- exiftool 缺失时清晰报错并退出非 0（不静默跳过）
- 想跳过：`git commit --no-verify`

**`package.json`** 新增 `prepare` script：
```json
"prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
```
clone 后跑一次 `npm install` 自动激活。`|| true` 兜底（不在 git repo 时不会让安装失败）。

**`tests/git-hook-pre-commit.test.mjs`** —— 3 个 case：
1. JPEG with GPS → 剥掉 + 重新 stage（验证 `:photo.jpg` 的 staged blob hash 等于 cleaned 文件 hash）
2. 只 stage README.md → 无输出、退出 0
3. JPEG 本来就没 GPS → 不报"Stripped"，退出 0（避免噪音）

## 影响

- **隐私**：彻底堵住 GPS 进入 git history 的路径。即使作者忘记在拍摄时关 GPS，hook 也会兜底
- **依赖**：开发机需要 `exiftool`（`brew install exiftool` / `apt-get install libimage-exiftool-perl`）。CI 不需要——hook 只在本地 commit 时跑
- **不影响**：现有 HEIC pipeline、Astro build、CI workflow；只在 `git commit` 时触发
- **绕过**：`git commit --no-verify`（紧急情况或处理已审计过的测试 fixture）

## 验证

- [x] `node --test tests/git-hook-pre-commit.test.mjs` —— 3/3 pass
- [ ] **手工验证**（合入后做一次）：本地拍一张带 GPS 的照片 / iPhone 导出 → 拖进 post 目录 → `git add` + `git commit` → 检查 `git show HEAD:<photo>` 用 exiftool 验证 GPS 已被剥