### PR TITLE
Fix theme flash on navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -42,6 +42,44 @@ const serializeStructuredData = (item: Record<string, unknown>) =>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+
+    <!-- Theme and first-paint background must run before stylesheet discovery. -->
+    <script is:inline data-critical-theme-init>
+      (() => {
+        try {
+          const stored = window.localStorage?.getItem('theme');
+          const theme = stored === 'dark' || stored === 'light'
+            ? stored
+            : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          const isDark = theme === 'dark';
+          document.documentElement.classList.toggle('dark', isDark);
+          document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+        } catch {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
+    <style is:inline data-critical-page-background>
+      :root {
+        background-color: oklch(97% 0.012 78);
+      }
+
+      html.dark {
+        background-color: oklch(18.5% 0.012 252);
+      }
+
+      html,
+      body {
+        min-height: 100%;
+        background-color: oklch(97% 0.012 78);
+      }
+
+      html.dark,
+      html.dark body {
+        background-color: oklch(18.5% 0.012 252);
+      }
+    </style>
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico?v=avatar" />
@@ -130,18 +168,6 @@ const serializeStructuredData = (item: Record<string, unknown>) =>
         }
       </script>
     )}
-
-    <!-- Dark mode init (prevent flash) -->
-    <script is:inline>
-      const theme = (() => {
-        const stored = localStorage?.getItem('theme');
-        if (stored === 'dark' || stored === 'light') return stored;
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      })();
-      const isDark = theme === 'dark';
-      document.documentElement.classList.toggle('dark', isDark);
-      document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
-    </script>
 
     <!-- Live Photo styles (no-op when no .livephoto exists on the page) -->
     <style is:global>

--- a/tests/ui-regressions.test.mjs
+++ b/tests/ui-regressions.test.mjs
@@ -127,6 +127,22 @@ test('theme toggle exposes localized motion-friendly labels', () => {
   assert.match(html, /data-label-dark="切换到深色模式"/);
 });
 
+test('theme and page background are initialized before stylesheet discovery', () => {
+  const html = readDist('index.html');
+  const firstStylesheet = html.indexOf('rel="stylesheet"');
+  const themeInit = html.indexOf('data-critical-theme-init');
+  const backgroundInit = html.indexOf('data-critical-page-background');
+
+  assert.notEqual(firstStylesheet, -1);
+  assert.notEqual(themeInit, -1);
+  assert.notEqual(backgroundInit, -1);
+  assert.ok(themeInit < firstStylesheet, 'theme init must run before stylesheet discovery');
+  assert.ok(backgroundInit < firstStylesheet, 'critical background must be inline before stylesheet discovery');
+  assert.match(html.slice(0, firstStylesheet), /html\.dark/);
+  assert.match(html.slice(0, firstStylesheet), /background-color:\s*oklch\(97% 0\.012 78\)/);
+  assert.match(html.slice(0, firstStylesheet), /background-color:\s*oklch\(18\.5% 0\.012 252\)/);
+});
+
 test('bamboo shadow uses JS wind physics instead of global keyframe or SMIL transforms', () => {
   const source = readSource('src', 'components', 'BambooShadow.astro');
 


### PR DESCRIPTION
## Summary
- Move theme initialization to the first part of `<head>` so dark/light class is set before stylesheet discovery.
- Inline a tiny critical first-paint background for light and dark paper colors to prevent white flashes while CSS is loading.
- Add a regression test that verifies theme/background initialization appears before stylesheet discovery in built HTML.

## Test Plan
- npm test
- git diff --check
- Playwright check with CSS requests delayed: homepage and `/archive/` first frames keep dark paper background before CSS loads, no console errors
